### PR TITLE
Structured logging across Sloop (plus null-value support)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.0] - 2025-07-23
+
+### Added
+
+- Structured logging across the library via `Microsoft.Extensions.Logging` ([LoggerMessage] extensions).
+
+### Changed
+
+- Support for storing and retrieving `null` values as cache items.
+
+---
+
 ## [2.0.0] - 2025-07-21
 
 ### Added

--- a/Sloop.Tests/Integration/SloopCacheTests.cs
+++ b/Sloop.Tests/Integration/SloopCacheTests.cs
@@ -6,6 +6,8 @@ using Commands;
 using Extensions;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using Testcontainers.PostgreSql;
 
@@ -36,6 +38,9 @@ public class SloopCacheTests : IAsyncLifetime
         await _db.StartAsync();
 
         var services = new ServiceCollection();
+
+        services.AddSingleton(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
         services.AddCache(opt =>
         {

--- a/Sloop/Abstractions/IDbCacheMigrator.cs
+++ b/Sloop/Abstractions/IDbCacheMigrator.cs
@@ -1,6 +1,11 @@
 namespace Sloop.Abstractions;
 
+/// <summary>Runs database migrations for the Sloop cache infrastructure.</summary>
 public interface IDbCacheMigrator
 {
+    /// <summary>
+    ///     Applies required schema/table updates for the cache store.
+    /// </summary>
+    /// <param name="ct">Token to cancel the migration.</param>
     Task MigrateAsync(CancellationToken ct = default);
 }

--- a/Sloop/Commands/RemoveItemCommand.cs
+++ b/Sloop/Commands/RemoveItemCommand.cs
@@ -2,6 +2,8 @@ namespace Sloop.Commands;
 
 using Abstractions;
 using Core;
+using Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Npgsql;
 
@@ -16,20 +18,26 @@ public record RemoveItemArgs(string Key);
 /// </summary>
 public class RemoveItemCommand : IDbCacheCommand<RemoveItemArgs, bool>
 {
+    private readonly ILogger<RemoveItemCommand> _logger;
+
     private readonly SloopOptions _options;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="RemoveItemCommand" /> class.
     /// </summary>
     /// <param name="options">The configured Sloop options.</param>
-    public RemoveItemCommand(IOptions<SloopOptions> options)
+    /// <param name="logger">The logger <see cref="ILogger" /></param>
+    public RemoveItemCommand(IOptions<SloopOptions> options, ILogger<RemoveItemCommand> logger)
     {
+        _logger = logger;
         _options = options.Value;
     }
 
     /// <inheritdoc />
     public async Task<bool> ExecuteAsync(NpgsqlConnection connection, RemoveItemArgs args, CancellationToken token = default)
     {
+        _logger.RemoveStart(args.Key);
+
         await using var cmd = connection.CreateCommand();
 
         cmd.CommandText =
@@ -40,7 +48,18 @@ public class RemoveItemCommand : IDbCacheCommand<RemoveItemArgs, bool>
 
         cmd.Parameters.AddWithValue("key", args.Key);
 
+        _logger.ExecutingSql(cmd.CommandText);
+
         var count = await cmd.ExecuteNonQueryAsync(token);
+
+        if (count == 0)
+        {
+            _logger.RemoveNoop(args.Key);
+        }
+        else
+        {
+            _logger.RemoveDeleted(args.Key, count);
+        }
 
         return count > 0;
     }

--- a/Sloop/Logging/Logging.Cleanup.cs
+++ b/Sloop/Logging/Logging.Cleanup.cs
@@ -1,0 +1,24 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        0,
+        LogLevel.Information,
+        "Sloop cleanup service started. Interval={interval}.")]
+    public static partial void CleanupStarted(this ILogger logger, TimeSpan interval);
+
+    [LoggerMessage(
+        0,
+        LogLevel.Information,
+        "Sloop cleanup service stopping.")]
+    public static partial void CleanupStopping(this ILogger logger);
+
+    [LoggerMessage(
+        0,
+        LogLevel.Error,
+        "Cleanup tick failed.")]
+    public static partial void CleanupFailed(this ILogger logger, Exception exception);
+}

--- a/Sloop/Logging/Logging.Common.cs
+++ b/Sloop/Logging/Logging.Common.cs
@@ -1,0 +1,12 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        (int)SloopEventId.ExecutingSql,
+        LogLevel.Trace,
+        "Executing SQL for cache migration:\n{sql}")]
+    public static partial void ExecutingSql(this ILogger logger, string sql);
+}

--- a/Sloop/Logging/Logging.GetItem.cs
+++ b/Sloop/Logging/Logging.GetItem.cs
@@ -1,0 +1,24 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        (int)SloopEventId.GetItemStart,
+        LogLevel.Debug,
+        "Retrieving cache item '{key}'.")]
+    public static partial void GetStart(this ILogger logger, string key);
+
+    [LoggerMessage(
+        (int)SloopEventId.GetItemHit,
+        LogLevel.Debug,
+        "Cache hit for key '{key}'.")]
+    public static partial void CacheHit(this ILogger logger, string key);
+
+    [LoggerMessage(
+        (int)SloopEventId.GetItemMiss,
+        LogLevel.Debug,
+        "Cache miss for key '{key}'.")]
+    public static partial void CacheMiss(this ILogger logger, string key);
+}

--- a/Sloop/Logging/Logging.Migrations.cs
+++ b/Sloop/Logging/Logging.Migrations.cs
@@ -1,0 +1,30 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        (int)SloopEventId.SkippingMigration,
+        LogLevel.Debug,
+        "CreateInfrastructure is false. Skipping cache migration.")]
+    public static partial void SkippingMigration(this ILogger logger);
+
+    [LoggerMessage(
+        (int)SloopEventId.StartingMigration,
+        LogLevel.Information,
+        "Applying cache migration ('{table}').")]
+    public static partial void StartingMigration(this ILogger logger, string table);
+
+    [LoggerMessage(
+        (int)SloopEventId.MigrationDone,
+        LogLevel.Information,
+        "Cache migration completed.")]
+    public static partial void MigrationDone(this ILogger logger);
+
+    [LoggerMessage(
+        0,
+        LogLevel.Error,
+        "Cache migration failed.")]
+    public static partial void MigrationFailed(this ILogger logger, Exception exception);
+}

--- a/Sloop/Logging/Logging.PurgeExpiredItems.cs
+++ b/Sloop/Logging/Logging.PurgeExpiredItems.cs
@@ -1,0 +1,30 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        (int)SloopEventId.PurgeStart,
+        LogLevel.Debug,
+        "Starting purge of expired items (limit={limit}).")]
+    public static partial void PurgeStart(this ILogger logger, long limit);
+
+    [LoggerMessage(
+        (int)SloopEventId.PurgeBatchDone,
+        LogLevel.Trace,
+        "Deleted {count} expired items in this batch.")]
+    public static partial void PurgeBatch(this ILogger logger, long count);
+
+    [LoggerMessage(
+        (int)SloopEventId.PurgeFinished,
+        LogLevel.Information,
+        "Finished purge. Total deleted={total}.")]
+    public static partial void PurgeFinished(this ILogger logger, long total);
+
+    [LoggerMessage(
+        (int)SloopEventId.PurgeCancelled,
+        LogLevel.Debug,
+        "Cancellation requested. Total deleted so far={total}.")]
+    public static partial void PurgeCancelled(this ILogger logger, long total);
+}

--- a/Sloop/Logging/Logging.RefreshItem.cs
+++ b/Sloop/Logging/Logging.RefreshItem.cs
@@ -1,0 +1,24 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        (int)SloopEventId.RefreshStart,
+        LogLevel.Debug,
+        "Refreshing cache item '{key}'.")]
+    public static partial void RefreshStart(this ILogger logger, string key);
+
+    [LoggerMessage(
+        (int)SloopEventId.RefreshUpdated,
+        LogLevel.Debug,
+        "Expiration refreshed for key '{key}'.")]
+    public static partial void RefreshUpdated(this ILogger logger, string key);
+
+    [LoggerMessage(
+        (int)SloopEventId.RefreshNoop,
+        LogLevel.Debug,
+        "No refresh performed for key '{key}'.")]
+    public static partial void RefreshNoop(this ILogger logger, string key);
+}

--- a/Sloop/Logging/Logging.RemoveItem.cs
+++ b/Sloop/Logging/Logging.RemoveItem.cs
@@ -1,0 +1,24 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        (int)SloopEventId.RemoveStart,
+        LogLevel.Debug,
+        "Removing cache item '{key}'.")]
+    public static partial void RemoveStart(this ILogger logger, string key);
+
+    [LoggerMessage(
+        (int)SloopEventId.RemoveDeleted,
+        LogLevel.Debug,
+        "Removed cache item '{key}'. Rows affected={count}.")]
+    public static partial void RemoveDeleted(this ILogger logger, string key, int count);
+
+    [LoggerMessage(
+        (int)SloopEventId.RemoveNoop,
+        LogLevel.Debug,
+        "No cache item removed for key '{key}'.")]
+    public static partial void RemoveNoop(this ILogger logger, string key);
+}

--- a/Sloop/Logging/Logging.SetItem.cs
+++ b/Sloop/Logging/Logging.SetItem.cs
@@ -1,0 +1,24 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        (int)SloopEventId.SetStart,
+        LogLevel.Debug,
+        "Setting cache item '{key}' ({length} bytes).")]
+    public static partial void SetStart(this ILogger logger, string key, int length);
+
+    [LoggerMessage(
+        (int)SloopEventId.SetStored,
+        LogLevel.Debug,
+        "Cache item '{key}' stored (upsert).")]
+    public static partial void SetStored(this ILogger logger, string key);
+
+    [LoggerMessage(
+        (int)SloopEventId.SetNoop,
+        LogLevel.Debug,
+        "No row affected for key '{key}'.")]
+    public static partial void SetNoop(this ILogger logger, string key);
+}

--- a/Sloop/Logging/Logging.TryAcquireLock.cs
+++ b/Sloop/Logging/Logging.TryAcquireLock.cs
@@ -1,0 +1,24 @@
+namespace Sloop.Logging;
+
+using Microsoft.Extensions.Logging;
+
+public static partial class LoggingExtensions
+{
+    [LoggerMessage(
+        (int)SloopEventId.TryLockStart,
+        LogLevel.Debug,
+        "Trying to acquire advisory lock '{id}'.")]
+    public static partial void TryLockStart(this ILogger logger, long id);
+
+    [LoggerMessage(
+        (int)SloopEventId.TryLockAcquired,
+        LogLevel.Debug,
+        "Acquired advisory lock '{id}'.")]
+    public static partial void TryLockAcquired(this ILogger logger, long id);
+
+    [LoggerMessage(
+        (int)SloopEventId.TryLockDenied,
+        LogLevel.Debug,
+        "Failed to acquire advisory lock '{id}'.")]
+    public static partial void TryLockDenied(this ILogger logger, long id);
+}

--- a/Sloop/Logging/SloopEventId.cs
+++ b/Sloop/Logging/SloopEventId.cs
@@ -1,0 +1,58 @@
+namespace Sloop.Logging;
+
+public enum SloopEventId
+{
+    // Common
+    ExecutingSql = 1002,
+
+    // Migration
+    StartingMigration = 2001,
+
+    SkippingMigration = 2000,
+
+    MigrationDone = 2003,
+
+    // GetItem
+    GetItemStart = 3000,
+
+    GetItemHit = 3002,
+
+    GetItemMiss = 3003,
+
+    // PurgeExpiredItems
+    PurgeStart = 4000,
+
+    PurgeBatchDone = 4001,
+
+    PurgeFinished = 4002,
+
+    PurgeCancelled = 4003,
+
+    // RefreshItem
+    RefreshStart = 5000,
+
+    RefreshUpdated = 5001,
+
+    RefreshNoop = 5002,
+
+    // RemoveItem
+    RemoveStart = 6000,
+
+    RemoveDeleted = 6001,
+
+    RemoveNoop = 6002,
+
+    // SetItem
+    SetStart = 7000,
+
+    SetStored = 7001,
+
+    SetNoop = 7002,
+
+    // TryAcquireLock
+    TryLockStart = 8000,
+
+    TryLockAcquired = 8001,
+
+    TryLockDenied = 8002
+}

--- a/Sloop/Services/SloopMigrationService.cs
+++ b/Sloop/Services/SloopMigrationService.cs
@@ -1,7 +1,9 @@
 namespace Sloop.Services;
 
 using Abstractions;
+using Logging;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 /// <summary>
 ///     A background service that runs cache schema migrations once when the host starts.
@@ -10,18 +12,37 @@ internal class SloopMigrationService : BackgroundService
 {
     private readonly IDbCacheContext _context;
 
+    private readonly ILogger<SloopMigrationService> _logger;
+
     /// <summary>
     ///     Initializes a new instance of the <see cref="SloopMigrationService" /> class.
     /// </summary>
     /// <param name="context">The cache context used to apply database migrations.</param>
-    public SloopMigrationService(IDbCacheContext context)
+    /// <param name="logger">The logger <see cref="ILogger" /></param>
+    public SloopMigrationService(IDbCacheContext context, ILogger<SloopMigrationService> logger)
     {
         _context = context;
+        _logger = logger;
     }
 
     /// <inheritdoc />
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        return _context.MigrateAsync(stoppingToken);
+        try
+        {
+            _context.MigrateAsync(stoppingToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // Do nothing, the service is stopping
+        }
+        catch (Exception ex)
+        {
+            _logger.MigrationFailed(ex);
+
+            throw;
+        }
+
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
### What
- Introduced `Microsoft.Extensions.Logging` with source‑generated `[LoggerMessage]` extensions (`Sloop.Logging`).
- Wired logging into all commands, hosted services, and migrator (common `ExecutingSql` + per‑operation events).
- Allowed `null` values to be stored/retrieved from the cache.

### Why
- Improve observability and testability without forcing consumers to configure custom loggers.
- Reduce log allocation cost via source generators.

### Changelog
Added a single bullet under **2.1.0**: “Structured logging across the library via `Microsoft.Extensions.Logging` ([LoggerMessage] extensions).”
