### PR TITLE
Fixed logging causing exceptions on null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.0.0] - 2025-07-23
+## [2.1.1] - 2025-07-23
+
+### Fixed
+
+- Fixed issue where null values were throwing exceptions with logging when stored in the cache.
+- Added tests to encapsulate null value handling in cache operations.
+
+---
+
+## [2.1.0] - 2025-07-23
 
 ### Added
 

--- a/Sloop/Commands/GetItemCommand.cs
+++ b/Sloop/Commands/GetItemCommand.cs
@@ -64,7 +64,7 @@ public class GetItemCommand : IDbCacheCommand<GetItemArgs, byte[]?>
             return null;
         }
 
-        _logger.CacheHit(args.Key);
+        _logger.CacheHit(args.Key, value?.Length ?? 0);
 
         return value;
     }

--- a/Sloop/Commands/SetItemCommand.cs
+++ b/Sloop/Commands/SetItemCommand.cs
@@ -44,7 +44,7 @@ public class SetItemCommand : IDbCacheCommand<SetItemArgs, bool>
     /// <inheritdoc />
     public async Task<bool> ExecuteAsync(NpgsqlConnection connection, SetItemArgs args, CancellationToken token = default)
     {
-        _logger.SetStart(args.Key, args.Value.Length);
+        _logger.SetStart(args.Key, args.Value?.Length ?? 0);
 
         var options = args.Options ?? new DistributedCacheEntryOptions();
 
@@ -70,10 +70,10 @@ public class SetItemCommand : IDbCacheCommand<SetItemArgs, bool>
              """;
 
         cmd.Parameters.AddWithValue("key", args.Key);
-        cmd.Parameters.AddWithValue("value", args.Value);
-        cmd.Parameters.AddWithValue("expires_at", expiration.HasValue ? expiration.Value.UtcDateTime : DBNull.Value);
-        cmd.Parameters.AddWithValue("sliding_interval", sliding.HasValue ? sliding.Value : DBNull.Value);
-        cmd.Parameters.AddWithValue("absolute_expiry", absolute.HasValue ? absolute.Value.UtcDateTime : DBNull.Value);
+        cmd.Parameters.AddWithValue("value", args.Value! ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("expires_at", expiration?.UtcDateTime! ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("sliding_interval", sliding! ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("absolute_expiry", absolute?.UtcDateTime! ?? (object)DBNull.Value);
 
         _logger.ExecutingSql(cmd.CommandText);
 

--- a/Sloop/Logging/Logging.GetItem.cs
+++ b/Sloop/Logging/Logging.GetItem.cs
@@ -13,8 +13,8 @@ public static partial class LoggingExtensions
     [LoggerMessage(
         (int)SloopEventId.GetItemHit,
         LogLevel.Debug,
-        "Cache hit for key '{key}'.")]
-    public static partial void CacheHit(this ILogger logger, string key);
+        "Cache hit for key '{key}' ({length} bytes).")]
+    public static partial void CacheHit(this ILogger logger, string key, long length);
 
     [LoggerMessage(
         (int)SloopEventId.GetItemMiss,

--- a/Sloop/Logging/Logging.SetItem.cs
+++ b/Sloop/Logging/Logging.SetItem.cs
@@ -8,7 +8,7 @@ public static partial class LoggingExtensions
         (int)SloopEventId.SetStart,
         LogLevel.Debug,
         "Setting cache item '{key}' ({length} bytes).")]
-    public static partial void SetStart(this ILogger logger, string key, int length);
+    public static partial void SetStart(this ILogger logger, string key, long length);
 
     [LoggerMessage(
         (int)SloopEventId.SetStored,


### PR DESCRIPTION
### Fixed

- Fixed issue where null values were throwing exceptions with logging when stored in the cache.
- Added tests to encapsulate null value handling in cache operations.